### PR TITLE
Provide `replicateA` instead of `replicateM`

### DIFF
--- a/papa-base-export/src/Papa/Base/Export/Control/Monad.hs
+++ b/papa-base-export/src/Papa/Base/Export/Control/Monad.hs
@@ -15,8 +15,6 @@ import Control.Monad as P(
   , filterM
   , foldM
   , foldM_
-  , replicateM
-  , replicateM_
   , guard
   , when
   , unless

--- a/papa-base-implement/default.nix
+++ b/papa-base-implement/default.nix
@@ -1,11 +1,11 @@
 { mkDerivation, base, directory, doctest, filepath, QuickCheck
-, semigroups, stdenv, template-haskell
+, semigroups, stdenv, template-haskell, papa-base-export
 }:
 mkDerivation {
   pname = "papa-base-implement";
   version = "0.2.0";
   src = ./.;
-  libraryHaskellDepends = [ base semigroups ];
+  libraryHaskellDepends = [ base semigroups papa-base-export ];
   testHaskellDepends = [
     base directory doctest filepath QuickCheck template-haskell
   ];

--- a/papa-base-implement/papa-base-implement.cabal
+++ b/papa-base-implement/papa-base-implement.cabal
@@ -28,6 +28,7 @@ library
   build-depends:
                     base >= 4.8 && < 5
                   , semigroups >= 0.18
+                  , papa-base-export >= 0.2.0 && < 1
                   
   ghc-options:
                     -Wall

--- a/papa-base-implement/src/Papa/Base/Implement/Control/Applicative.hs
+++ b/papa-base-implement/src/Papa/Base/Implement/Control/Applicative.hs
@@ -5,6 +5,9 @@ module Papa.Base.Implement.Control.Applicative(
 ) where
 
 import Control.Applicative(Applicative(pure))
+import Control.Monad (replicateM, replicateM_)
+
+import Papa.Base.Export.Prelude (Int)
 
 const ::
   Applicative f =>
@@ -13,3 +16,8 @@ const ::
 const =
   pure
 
+replicateA :: Applicative f => Int -> f a -> f [a]
+replicateA = replicateM
+
+replicateA_ :: Applicative f => Int -> f a -> f () 
+replicateA_= replicateM_

--- a/papa-base-implement/src/Papa/Base/Implement/Control/Applicative.hs
+++ b/papa-base-implement/src/Papa/Base/Implement/Control/Applicative.hs
@@ -2,6 +2,8 @@
 
 module Papa.Base.Implement.Control.Applicative(
   const
+, replicateA
+, replicateA_
 ) where
 
 import Control.Applicative(Applicative(pure))

--- a/papa-example/src/Papa/Example.hs
+++ b/papa-example/src/Papa/Example.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
 module Papa.Example where
 
-import Papa
+import           Papa
 
 -- |
 --
@@ -63,7 +65,7 @@ initExample =
 --
 -- >>> indexExample
 -- (Nothing,Just 'b',Nothing,Just 'a',Nothing,Nothing,Just 'c',Just 17)
-indexExample :: 
+indexExample ::
   (
     Maybe a
   , Maybe Char


### PR DESCRIPTION
I didn't know we would prefer to keep the Monad versions, so I took them out.