### PR TITLE
Adds an implementation of `replicateA` for GHC 7.10.3

### DIFF
--- a/papa-base-implement/src/Papa/Base/Implement/Control/Applicative.hs
+++ b/papa-base-implement/src/Papa/Base/Implement/Control/Applicative.hs
@@ -6,10 +6,10 @@ module Papa.Base.Implement.Control.Applicative(
 , replicateA_
 ) where
 
-import Control.Applicative(Applicative(pure))
+import Control.Applicative(Applicative(pure), liftA2, (*>))
 import Control.Monad (replicateM, replicateM_)
 
-import Papa.Base.Export.Prelude (Int)
+import Papa.Base.Export.Prelude (Int, Maybe, IO, (-), (<=), otherwise)
 
 const ::
   Applicative f =>
@@ -18,8 +18,24 @@ const ::
 const =
   pure
 
-replicateA :: Applicative f => Int -> f a -> f [a]
-replicateA = replicateM
+replicateA        :: (Applicative f) => Int -> f a -> f [a]
+{-# INLINABLE replicateA #-}
+{-# SPECIALISE replicateA :: Int -> IO a -> IO [a] #-}
+{-# SPECIALISE replicateA :: Int -> Maybe a -> Maybe [a] #-}
+replicateA cnt0 f =
+    loop cnt0
+  where
+    loop cnt
+        | cnt <= 0  = pure []
+        | otherwise = liftA2 (:) f (loop (cnt - 1))
 
-replicateA_ :: Applicative f => Int -> f a -> f () 
-replicateA_= replicateM_
+replicateA_       :: (Applicative f) => Int -> f a -> f ()
+{-# INLINABLE replicateA_ #-}
+{-# SPECIALISE replicateA_ :: Int -> IO a -> IO () #-}
+{-# SPECIALISE replicateA_ :: Int -> Maybe a -> Maybe () #-}
+replicateA_ cnt0 f =
+    loop cnt0
+  where
+    loop cnt
+        | cnt <= 0  = pure ()
+        | otherwise = f *> loop (cnt - 1)


### PR DESCRIPTION
This comes from the current base, and so should be pretty efficient.