### PR TITLE
Adds a dependency on `semigroups`, to make things work with older GHCs.

### DIFF
--- a/papa-base-export/default.nix
+++ b/papa-base-export/default.nix
@@ -1,11 +1,11 @@
 { mkDerivation, base, directory, doctest, filepath, QuickCheck
-, stdenv, template-haskell
+, semigroups, stdenv, template-haskell 
 }:
 mkDerivation {
   pname = "papa-base-export";
   version = "0.2.0";
   src = ./.;
-  libraryHaskellDepends = [ base ];
+  libraryHaskellDepends = [ base semigroups ];
   testHaskellDepends = [
     base directory doctest filepath QuickCheck template-haskell
   ];

--- a/papa-base-export/papa-base-export.cabal
+++ b/papa-base-export/papa-base-export.cabal
@@ -27,6 +27,7 @@ library
 
   build-depends:
                     base >= 4.8 && < 5
+                  , semigroups >= 0.18 && < 0.19
                     
   ghc-options:
                     -Wall

--- a/papa-semigroupoids-implement/default.nix
+++ b/papa-semigroupoids-implement/default.nix
@@ -1,11 +1,11 @@
 { mkDerivation, base, directory, doctest, filepath, QuickCheck
-, semigroupoids, stdenv, template-haskell
+, semigroups, semigroupoids, stdenv, template-haskell
 }:
 mkDerivation {
   pname = "papa-semigroupoids-implement";
   version = "0.2.0";
   src = ./.;
-  libraryHaskellDepends = [ base semigroupoids ];
+  libraryHaskellDepends = [ base semigroups semigroupoids ];
   testHaskellDepends = [
     base directory doctest filepath QuickCheck template-haskell
   ];

--- a/papa-semigroupoids-implement/papa-semigroupoids-implement.cabal
+++ b/papa-semigroupoids-implement/papa-semigroupoids-implement.cabal
@@ -28,6 +28,7 @@ library
   build-depends:
                     base >= 4.8 && < 5
                     , semigroupoids >= 5 && < 6
+                    , semigroups >= 0.18 && < 0.19
                     
   ghc-options:
                     -Wall


### PR DESCRIPTION
The `semigroups` package has all the CPP that we need to handle the
fact that parts of it have moved into `base`.