### PR TITLE
Adds the first part of the Hydra support.

### DIFF
--- a/ci/ci.nix
+++ b/ci/ci.nix
@@ -1,0 +1,56 @@
+{ supportedSystems ? ["x86_64-linux"]
+, supportedCompilers ? [ "ghc7103" "ghc802" "ghc821" ] 
+, papaPackages ? [
+    "papa-example"
+    "papa"
+    "papa-base"
+    "papa-base-export"
+    "papa-base-implement"
+    "papa-bifunctors"
+    "papa-bifunctors-export"
+    "papa-bifunctors-implement"
+    "papa-lens"
+    "papa-lens-implement"
+    "papa-lens-export"
+    "papa-semigroupoids"
+    "papa-semigroupoids-implement"
+    "papa-semigroupoids-export"
+    "papa-x"
+    "papa-x-implement"
+    "papa-x-export"
+    ]
+}:
+
+with (import <nixpkgs/pkgs/top-level/release-lib.nix> { inherit supportedSystems; });
+
+let
+  pkgs = import <nixpkgs> {};
+
+  configurations = 
+    pkgs.lib.listToAttrs (
+      pkgs.lib.concatMap (papaPackage: 
+        pkgs.lib.concatMap (compiler: 
+          pkgs.lib.concatMap (system: 
+            [{name = "haskell.packages." + compiler + "." + papaPackage + "." + system ; value = {inherit papaPackage compiler system;};}]
+          ) supportedSystems
+        ) supportedCompilers
+      ) papaPackages
+    );
+
+  jobs =
+      pkgs.lib.mapAttrs (name: configuration: 
+          let
+            papaPackage = configuration.papaPackage;
+            compiler = configuration.compiler; 
+            system = configuration.system; 
+            pkgs = pkgsFor system;
+            jailbreakLatest = p: if compiler == "ghc821" then pkgs.haskell.lib.doJailbreak p else p;
+            haskellPackages = pkgs.haskell.packages.${compiler}.override { 
+              overrides = self: super: (import ../. self);
+            };
+            pkg = haskellPackages.callPackage (../. + "/${papaPackage}/") {};
+          in
+            pkg
+      ) configurations;
+in
+  jobs

--- a/ci/jobsets.json
+++ b/ci/jobsets.json
@@ -1,0 +1,16 @@
+{
+    "enabled": 1,
+    "hidden": false,
+    "description": "jobsets",
+    "nixexprinput": "papa",
+    "nixexprpath": "ci/jobsets.nix",
+    "checkinterval": 300,
+    "schedulingshares": 1,
+    "enableemail": false,
+    "emailoverride": "",
+    "keepnr": 5,
+    "inputs": {
+        "papa": { "type": "git", "value": "https://github.com/data61/papa.git qfpl", "emailresponsible": false },
+        "nixpkgs": { "type": "git", "value": "https://github.com/NixOS/nixpkgs.git release-17.03", "emailresponsible": false }
+    }
+}

--- a/ci/jobsets.nix
+++ b/ci/jobsets.nix
@@ -1,0 +1,27 @@
+{ nixpkgs, declInput }: let pkgs = import nixpkgs {}; in {
+  jobsets = pkgs.runCommand "spec.json" {} ''
+    cat <<EOF
+    ${builtins.toXML declInput}
+    EOF
+    cat > $out <<EOF
+    {
+        "fp-course": {
+            "enabled": 1,
+            "hidden": false,
+            "description": "Papa",
+            "nixexprinput": "papa",
+            "nixexprpath": "./ci/ci.nix",
+            "checkinterval": 300,
+            "schedulingshares": 1,
+            "enableemail": false,
+            "emailoverride": "",
+            "keepnr": 5,
+            "inputs": {
+                "papa": { "type": "git", "value": "https://github.com/data61/papa.git qfpl", "emailresponsible": false },
+                "nixpkgs": { "type": "git", "value": "https://github.com/NixOS/nixpkgs.git release-17.03", "emailresponsible": false }
+            }
+        }
+    }
+    EOF
+  '';
+}


### PR DESCRIPTION
Once we switch to `qfpl` as the default working branch and add
 a `hydra` user in the organization to push the compiling changes
from the `qfpl` branch to the `master` branch we'll be good to go.

We may want to turn GHC 8.2.1 off for a while or wait for the
dust to settle before we use Hydra as a gatekeeper.