### PR TITLE
Changes how modules are exported, for haddock

### DIFF
--- a/papa-base-export/src/Papa/Base/Export.hs
+++ b/papa-base-export/src/Papa/Base/Export.hs
@@ -1,29 +1,49 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export(
-  module P
+    module Papa.Base.Export.Control.Applicative,
+    module Papa.Base.Export.Control.Category,
+    module Papa.Base.Export.Control.Monad,
+    module Papa.Base.Export.Data.Bool,
+    module Papa.Base.Export.Data.Char,
+    module Papa.Base.Export.Data.Either,
+    module Papa.Base.Export.Data.Eq,
+    module Papa.Base.Export.Data.Foldable,
+    module Papa.Base.Export.Data.Function,
+    module Papa.Base.Export.Data.Functor,
+    module Papa.Base.Export.Data.Int,
+    module Papa.Base.Export.Data.List,
+    module Papa.Base.Export.Data.List.NonEmpty,
+    module Papa.Base.Export.Data.Maybe,
+    module Papa.Base.Export.Data.Monoid,
+    module Papa.Base.Export.Data.Ord,
+    module Papa.Base.Export.Data.Ratio,
+    module Papa.Base.Export.Data.Semigroup,
+    module Papa.Base.Export.Data.String,
+    module Papa.Base.Export.Data.Traversable,
+    module Papa.Base.Export.Data.Void,
+    module Papa.Base.Export.Prelude
 ) where
 
-import Papa.Base.Export.Control.Applicative as P
-import Papa.Base.Export.Control.Category as P
-import Papa.Base.Export.Control.Monad as P
-import Papa.Base.Export.Data.Bool as P
-import Papa.Base.Export.Data.Char as P
-import Papa.Base.Export.Data.Either as P
-import Papa.Base.Export.Data.Eq as P
-import Papa.Base.Export.Data.Foldable as P
-import Papa.Base.Export.Data.Function as P
-import Papa.Base.Export.Data.Functor as P
-import Papa.Base.Export.Data.Int as P
-import Papa.Base.Export.Data.List as P
-import Papa.Base.Export.Data.List.NonEmpty as P
-import Papa.Base.Export.Data.Maybe as P
-import Papa.Base.Export.Data.Monoid as P
-import Papa.Base.Export.Data.Ord as P
-import Papa.Base.Export.Data.Ratio as P
-import Papa.Base.Export.Data.Semigroup as P
-import Papa.Base.Export.Data.String as P
-import Papa.Base.Export.Data.Traversable as P
-import Papa.Base.Export.Data.Void as P
-import Papa.Base.Export.Prelude as P
-
+import Papa.Base.Export.Control.Applicative
+import Papa.Base.Export.Control.Category
+import Papa.Base.Export.Control.Monad
+import Papa.Base.Export.Data.Bool
+import Papa.Base.Export.Data.Char
+import Papa.Base.Export.Data.Either
+import Papa.Base.Export.Data.Eq
+import Papa.Base.Export.Data.Foldable
+import Papa.Base.Export.Data.Function
+import Papa.Base.Export.Data.Functor
+import Papa.Base.Export.Data.Int
+import Papa.Base.Export.Data.List
+import Papa.Base.Export.Data.List.NonEmpty
+import Papa.Base.Export.Data.Maybe
+import Papa.Base.Export.Data.Monoid
+import Papa.Base.Export.Data.Ord
+import Papa.Base.Export.Data.Ratio
+import Papa.Base.Export.Data.Semigroup
+import Papa.Base.Export.Data.String
+import Papa.Base.Export.Data.Traversable
+import Papa.Base.Export.Data.Void
+import Papa.Base.Export.Prelude

--- a/papa-base-export/src/Papa/Base/Export/Control/Applicative.hs
+++ b/papa-base-export/src/Papa/Base/Export/Control/Applicative.hs
@@ -1,10 +1,22 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Control.Applicative(
-  module P
+    Applicative(pure, (<*>), (*>), (<*))
+  , Alternative(empty, (<|>), some, many)
+  , Const(getConst)
+  , WrappedMonad(unwrapMonad)
+  , WrappedArrow(unwrapArrow)
+  , ZipList(getZipList)
+  , (<$>)
+  , (<$)
+  , (<**>)
+  , liftA
+  , liftA2
+  , liftA3
+  , optional
 ) where
 
-import Control.Applicative as P(
+import Control.Applicative (
     Applicative(pure, (<*>), (*>), (<*))
   , Alternative(empty, (<|>), some, many)
   , Const(getConst)

--- a/papa-base-export/src/Papa/Base/Export/Control/Category.hs
+++ b/papa-base-export/src/Papa/Base/Export/Control/Category.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Control.Category(
-  module P
+    Category(id, (.))
 ) where
 
-import Control.Category as P(
+import Control.Category (
     Category(id, (.))
   )

--- a/papa-base-export/src/Papa/Base/Export/Control/Monad.hs
+++ b/papa-base-export/src/Papa/Base/Export/Control/Monad.hs
@@ -1,10 +1,25 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Control.Monad(
-  module P
+    Functor(fmap)
+  , Monad((>>=), return, (>>))
+  , MonadPlus(mzero, mplus)
+  , forever
+  , void
+  , msum
+  , mfilter
+  , filterM
+  , foldM
+  , foldM_
+  , replicateM
+  , replicateM_
+  , guard
+  , when
+  , unless
+  , (<$!>)
 ) where
 
-import Control.Monad as P(
+import Control.Monad (
     Functor(fmap)
   , Monad((>>=), return, (>>))
   , MonadPlus(mzero, mplus)

--- a/papa-base-export/src/Papa/Base/Export/Data/Bool.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Bool.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Bool(
-  module P
+    (&&)
+  , (||)
+  , not
+  , otherwise
+  , bool
 ) where
 
-import Data.Bool as P(
+import Data.Bool (
     (&&)
   , (||)
   , not

--- a/papa-base-export/src/Papa/Base/Export/Data/Char.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Char.hs
@@ -1,10 +1,36 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Char(
-  module P
+    Char
+  , isControl
+  , isSpace
+  , isLower
+  , isUpper
+  , isAlpha
+  , isAlphaNum
+  , isPrint
+  , isDigit
+  , isOctDigit
+  , isHexDigit
+  , isLetter
+  , isMark
+  , isNumber
+  , isPunctuation
+  , isSymbol
+  , isSeparator
+  , isAscii
+  , isLatin1
+  , isAsciiUpper
+  , isAsciiLower
+  , GeneralCategory(UppercaseLetter, LowercaseLetter, TitlecaseLetter, ModifierLetter, OtherLetter, NonSpacingMark, SpacingCombiningMark, EnclosingMark, DecimalNumber, LetterNumber, OtherNumber, ConnectorPunctuation, DashPunctuation, OpenPunctuation, ClosePunctuation, InitialQuote, FinalQuote, OtherPunctuation, MathSymbol, CurrencySymbol, ModifierSymbol, OtherSymbol, Space, LineSeparator, ParagraphSeparator, Control, Format, Surrogate, PrivateUse, NotAssigned)
+  , toUpper
+  , toLower
+  , toTitle
+  , ord
+  , chr
 ) where
 
-import Data.Char as P(
+import Data.Char (
     Char
   , isControl
   , isSpace

--- a/papa-base-export/src/Papa/Base/Export/Data/Either.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Either.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Either(
-  module P
+    Either(Left, Right)
+  , either
+  , isLeft
+  , isRight
+  , partitionEithers
 ) where
 
-import Data.Either as P(
+import Data.Either (
     Either(Left, Right)
   , either
   , isLeft

--- a/papa-base-export/src/Papa/Base/Export/Data/Eq.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Eq.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Eq(
-  module P
+    Eq((==), (/=))
 ) where
 
-import Data.Eq as P(
+import Data.Eq (
     Eq((==), (/=))
   )
 

--- a/papa-base-export/src/Papa/Base/Export/Data/Foldable.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Foldable.hs
@@ -1,10 +1,22 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Foldable(
-  module P
+    Foldable(fold, foldMap, foldr, foldr', foldl, foldl', toList, null, elem, sum, product)
+  , foldrM
+  , foldlM
+  , traverse_
+  , for_
+  , sequenceA_
+  , asum
+  , and
+  , or
+  , any
+  , all
+  , notElem
+  , find
 ) where
 
-import Data.Foldable as P(
+import Data.Foldable (
     Foldable(fold, foldMap, foldr, foldr', foldl, foldl', toList, null, elem, sum, product)
   , foldrM
   , foldlM

--- a/papa-base-export/src/Papa/Base/Export/Data/Function.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Function.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Function(
-  module P
+    ($)
+  , (&)
+  , fix
+  , on
 ) where
 
-import Data.Function as P(
+import Data.Function (
     ($)
   , (&)
   , fix

--- a/papa-base-export/src/Papa/Base/Export/Data/Functor.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Functor.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Functor(
-  module P
+    Functor(fmap, (<$))
+  , ($>)
+  , (<$>)
+  , void
 ) where
 
-import Data.Functor as P(
+import Data.Functor (
     Functor(fmap, (<$))
   , ($>)
   , (<$>)

--- a/papa-base-export/src/Papa/Base/Export/Data/Int.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Int.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Int(
-  module P
+    Int
+  , Int8
+  , Int16
+  , Int32
+  , Int64
 ) where
 
-import Data.Int as P(
+import Data.Int (
     Int
   , Int8
   , Int16

--- a/papa-base-export/src/Papa/Base/Export/Data/List.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/List.hs
@@ -1,10 +1,70 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.List(
-  module P
+    null
+  , length
+  , reverse
+  , intersperse
+  , intercalate
+  , transpose
+  , subsequences
+  , permutations
+  , foldl
+  , foldl'
+  , foldr
+  , and
+  , or
+  , any
+  , all
+  , sum
+  , product
+  , mapAccumL
+  , mapAccumR
+  , replicate
+  , cycle
+  , take
+  , drop
+  , splitAt
+  , takeWhile
+  , dropWhile
+  , dropWhileEnd
+  , span
+  , break
+  , stripPrefix
+  , isPrefixOf
+  , isSuffixOf
+  , isInfixOf
+  , isSubsequenceOf
+  , elem
+  , notElem
+  , find
+  , partition
+  , lines
+  , words
+  , unlines
+  , unwords
+  , nub
+  , delete
+  , (\\)
+  , union
+  , intersect
+  , sort
+  , sortOn
+  , nubBy
+  , deleteBy
+  , deleteFirstsBy
+  , unionBy
+  , intersectBy
+  , sortBy
+  , insertBy
+  , genericLength
+  , genericTake
+  , genericDrop
+  , genericSplitAt
+  , genericReplicate
 ) where
 
-import Data.List as P(
+import Data.List (
     null
   , length
   , reverse

--- a/papa-base-export/src/Papa/Base/Export/Data/List/NonEmpty.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/List/NonEmpty.hs
@@ -1,10 +1,31 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.List.NonEmpty(
-  module P
+    NonEmpty((:|))
+  , scanl
+  , scanr
+  , scanl1
+  , scanr1
+  , inits
+  , tails
+  , iterate
+  , repeat
+  , unfold
+  , insert
+  , some1
+  , group
+  , groupBy
+  , groupWith
+  , groupAllWith
+  , group1
+  , groupBy1
+  , groupWith1
+  , groupAllWith1
+  , nonEmpty
+  , xor
 ) where
 
-import Data.List.NonEmpty as P(
+import Data.List.NonEmpty (
     NonEmpty((:|))
   , scanl
   , scanr

--- a/papa-base-export/src/Papa/Base/Export/Data/Maybe.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Maybe.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Maybe(
-  module P
+    Maybe(Nothing, Just)
+  , maybe
+  , isJust
+  , isNothing
+  , fromMaybe
 ) where
 
-import Data.Maybe as P(
+import Data.Maybe (
     Maybe(Nothing, Just)
   , maybe
   , isJust

--- a/papa-base-export/src/Papa/Base/Export/Data/Monoid.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Monoid.hs
@@ -1,10 +1,16 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Monoid(
-  module P  
+    Monoid(mempty, mappend)
+  , Dual(getDual)
+  , Endo(appEndo)
+  , All(getAll)
+  , Any(getAny)
+  , Sum(getSum)
+  , Product(getProduct)
 ) where
 
-import Data.Monoid as P(
+import Data.Monoid (
     Monoid(mempty, mappend)
   , Dual(getDual)
   , Endo(appEndo)

--- a/papa-base-export/src/Papa/Base/Export/Data/Ord.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Ord.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Ord(
-  module P
+    Ord(compare, (<), (<=), (>), (>=), max, min)
+  , Down(Down)
+  , comparing
 ) where
 
-import Data.Ord as P(
+import Data.Ord (
     Ord(compare, (<), (<=), (>), (>=), max, min)
   , Down(Down)
   , comparing

--- a/papa-base-export/src/Papa/Base/Export/Data/Ratio.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Ratio.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Ratio(
-  module P
+    Ratio
+  , Rational
+  , (%)
+  , numerator
+  , denominator
+  , approxRational
 ) where
 
-import Data.Ratio as P(
+import Data.Ratio (
     Ratio
   , Rational
   , (%)

--- a/papa-base-export/src/Papa/Base/Export/Data/Semigroup.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Semigroup.hs
@@ -1,10 +1,34 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Semigroup(
-  module P
+    Semigroup((<>), sconcat, stimes)
+  , stimesMonoid
+  , stimesIdempotent
+  , stimesIdempotentMonoid
+  , mtimesDefault
+  , Min(getMin)
+  , Max(getMax)
+  , First(getFirst)
+  , Last(getLast)
+  , WrappedMonoid(unwrapMonoid)
+  , Monoid(mempty, mappend)
+  , Dual(getDual)
+  , Endo(appEndo)
+  , All(getAll)
+  , Any(getAny)
+  , Sum(getSum)
+  , Product(getProduct)
+  , Option(getOption)
+  , option
+  , diff
+  , cycle1
+  , WrappedMonoid(unwrapMonoid)
+  , Arg(Arg)
+  , ArgMin
+  , ArgMax
 ) where
 
-import Data.Semigroup as P(
+import Data.Semigroup (
     Semigroup((<>), sconcat, stimes)
   , stimesMonoid
   , stimesIdempotent

--- a/papa-base-export/src/Papa/Base/Export/Data/String.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/String.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.String(
-  module P
+    String
+  , lines
+  , words
+  , unlines
+  , unwords
 ) where
 
-import Data.String as P(
+import Data.String (
     String
   , lines
   , words

--- a/papa-base-export/src/Papa/Base/Export/Data/Traversable.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Traversable.hs
@@ -1,10 +1,14 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Traversable(
-  module P
+    Traversable(traverse, sequenceA)
+  , for
+  , mapAccumL
+  , fmapDefault
+  , foldMapDefault
 ) where
 
-import Data.Traversable as P(
+import Data.Traversable (
     Traversable(traverse, sequenceA)
   , for
   , mapAccumL

--- a/papa-base-export/src/Papa/Base/Export/Data/Void.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/Void.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.Void(
-  module P
+    Void
+  , absurd
+  , vacuous
 ) where
 
-import Data.Void as P(
+import Data.Void (
     Void
   , absurd
   , vacuous

--- a/papa-base-export/src/Papa/Base/Export/Prelude.hs
+++ b/papa-base-export/src/Papa/Base/Export/Prelude.hs
@@ -1,11 +1,267 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Prelude(
-  module Prelude
+  --  (!!)                       Papa.Prelude.Lens.Data.List
+    Monad
+  , encodeFloat
+--, map                        Papa.Core.Data.Functor
+--, scanr                      Papa.Prelude.Semigroups.Data.List
+  , ($)
+  , Monoid 
+--, enumFrom
+--, mapM                       Papa.Core.Data.Traversable
+--, scanr1
+--, ($!) 
+--, enumFromThen
+--, mapM_                      Papa.Core.Data.Foldable
+--, seq
+  , (&&)
+  , Num 
+--, enumFromThenTo
+--, mappend                    Papa.Prelude.Semigroups.Data.List
+--, sequence                   Papa.Core.Data.Traversable
+  , (*)
+  , Ord 
+--, enumFromTo
+  , max 
+  , sequenceA
+  , (**)
+  , Ordering(
+      LT
+    , EQ
+    , GT
+    )
+--, error 
+--, maxBound
+--, sequence_                  Papa.Core.Data.Foldable
+--, (*>)                       Papa.Prelude.Semigroupoids.Data.Functor.Bind
+  , Rational
+--, errorWithoutStackTrace
+--, maximum                    Papa.Prelude.Semigroups.Data.List
+  , show
+  , (+) 
+--, Read 
+  , even 
+  , maybe 
+--, showChar
+--, (++)                       Papa.Prelude.Semigroups.Data.List
+--, ReadS 
+  , exp 
+--, mconcat                    Papa.Core.Data.Monoid
+--, showList
+  , (-) 
+  , Real 
+  , exponent
+  , mempty 
+  , showParen
+--, (.)                        Papa.Prelude.Semigroupoids.Data.Semigroupoid
+  , RealFloat
+--, fail 
+  , min 
+--, showString
+  , (/) 
+--, RealFrac
+  , filter 
+--, minBound
+  , shows
+  , (/=) 
+--, flip                       Papa.Core.Data.Functor
+--, minimum                    Papa.Prelude.Semigroups.Data.List
+  , showsPrec
+  , (<) 
+  , Show 
+  , floatDigits
+  , mod 
+  , significand
+  , (<$) 
+  , ShowS 
+  , floatRadix
+  , negate 
+  , signum
+  , (<$>)
+--, String 
+  , floatRange
+  , not 
+  , sin
+--, (<*)                       Papa.Prelude.Semigroupoids.Data.Functor.Bind
+  , Traversable
+  , floor 
+  , notElem 
+  , sinh
+  , (<*>)
+  , fmap 
+  , null 
+--, snd                        Papa.Prelude.Lens.Data.Tuple
+  , (<=)
+  , Word 
+  , foldMap 
+  , odd 
+  , span
+--, (=<<)                      Papa.Prelude.Semigroupoids.Data.Functor.Bind
+  , (^)
+  , foldl
+--, or 
+  , splitAt
+  , (==) 
+  , (^^) 
+--, foldl1                     Papa.Prelude.Semigroups.Data.List 
+  , otherwise
+  , sqrt
+  , (>) 
+  , abs 
+  , foldr 
+  , pi 
+  , subtract
+  , (>=) 
+  , acos 
+--, foldr1                     Papa.Prelude.Semigroups.Data.List
+--, pred 
+--, succ
+--, (>>)                       Papa.Prelude.Semigroupoids.Data.Functor.Apply
+  , acosh 
+--, fromEnum
+--, print 
+  , sum
+--, (>>=)                      Papa.Prelude.Semigroupoids.Data.Functor.Bind
+  , all 
+  , fromInteger
+  , product 
+--, tail                       Papa.Prelude.Lens.Data.List
+  , Applicative
+  , and 
+  , fromIntegral
+  , properFraction
+  , take
+  , Bool(
+      False
+    , True
+    ) 
+  , any 
+  , fromRational
+  , pure 
+  , takeWhile
+--, Bounded 
+  , appendFile
+--, fst                        Papa.Prelude.Lens.Data.Tuple
+  , putChar 
+  , tan
+  , Char 
+--, asTypeOf
+  , gcd 
+  , putStr 
+  , tanh
+  , Double 
+  , asin 
+  , getChar 
+  , putStrLn
+--, toEnum
+  , asinh 
+  , getContents
+  , quot 
+  , toInteger
+  , Either(
+      Left
+    , Right
+    ) 
+  , atan 
+  , getLine 
+  , quotRem 
+  , toRational
+  , Enum 
+  , atan2 
+--, head                       Papa.Prelude.Lens.Data.List 
+--, read 
+  , traverse
+  , Eq 
+  , atanh 
+--, id                         Papa.Core.Control.Category
+  , readFile
+  , truncate
+  , break 
+--, init                       Papa.Prelude.Lens.Data.List
+  , readIO 
+  , uncurry
+  , FilePath
+  , ceiling 
+  , interact
+--, readList
+--, undefined
+  , Float 
+  , compare 
+  , ioError 
+--, readLn 
+  , unlines
+  , Floating
+--, concat                     Papa.Prelude.Semigroupoids.Data.Functor.Bind
+  , isDenormalized
+--, readParen
+  , until
+  , Foldable
+--, concatMap                  Papa.Prelude.Semigroupoids.Data.Functor.Bind
+  , isIEEE 
+--, reads 
+  , unwords
+  , Fractional
+--, const                      Papa.Core.Control.Applicative
+  , isInfinite
+--, readsPrec
+--, unzip                      Papa.Core.Data.Functor
+  , Functor
+  , cos 
+  , isNaN 
+  , realToFrac
+  , unzip3
+  , cosh 
+  , isNegativeZero
+  , recip 
+--, userError
+  , IO 
+  , curry 
+--, iterate 
+  , rem 
+  , words
+  , IOError 
+  , cycle 
+--, last                       Papa.Prelude.Lens.Data.List
+--, repeat 
+  , writeFile
+  , Int 
+  , decodeFloat
+  , lcm 
+  , replicate
+  , zip
+  , Integer 
+--, div 
+--, length 
+--, return                     Papa.Core.Control.Applicative
+  , zip3
+  , Integral
+  , divMod
+--, lex 
+--, reverse                    Papa.Core.Data.List
+  , zipWith
+  , drop 
+  , lines 
+  , round 
+  , zipWith3
+  , dropWhile
+  , log 
+  , scaleFloat
+  , (||)
+  , either 
+  , logBase 
+--, scanl                      Papa.Prelude.Semigroups.Data.List
+  , Maybe(
+      Nothing
+    , Just
+    ) 
+  , elem 
+--, lookup                     Papa.Core.Data.List
+--, scanl1
 ) where
 
-import Prelude as Prelude(
---  (!!)                       Papa.Prelude.Lens.Data.List
+import Prelude (
+  --  (!!)                       Papa.Prelude.Lens.Data.List
     Monad
   , encodeFloat
 --, map                        Papa.Core.Data.Functor

--- a/papa-base-implement/src/Papa/Base/Implement.hs
+++ b/papa-base-implement/src/Papa/Base/Implement.hs
@@ -1,14 +1,21 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Implement(
-  module P
+    module Papa.Base.Implement.Control.Applicative,
+    module Papa.Base.Implement.Control.Monad,
+    module Papa.Base.Implement.Data.Foldable,
+    module Papa.Base.Implement.Data.Functor,
+    module Papa.Base.Implement.Data.Function,
+    module Papa.Base.Implement.Data.List,
+    module Papa.Base.Implement.Data.Monoid,
+    module Papa.Base.Implement.Data.Traversable
 ) where
 
-import Papa.Base.Implement.Control.Applicative as P
-import Papa.Base.Implement.Control.Monad as P
-import Papa.Base.Implement.Data.Foldable as P
-import Papa.Base.Implement.Data.Functor as P
-import Papa.Base.Implement.Data.Function as P
-import Papa.Base.Implement.Data.List as P
-import Papa.Base.Implement.Data.Monoid as P
-import Papa.Base.Implement.Data.Traversable as P
+import Papa.Base.Implement.Control.Applicative
+import Papa.Base.Implement.Control.Monad
+import Papa.Base.Implement.Data.Foldable
+import Papa.Base.Implement.Data.Functor
+import Papa.Base.Implement.Data.Function
+import Papa.Base.Implement.Data.List
+import Papa.Base.Implement.Data.Monoid
+import Papa.Base.Implement.Data.Traversable

--- a/papa-base/src/Papa/Base.hs
+++ b/papa-base/src/Papa/Base.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base(
-  module P
+  module Papa.Base.Export,
+  module Papa.Base.Implement
 ) where
 
-import Papa.Base.Export as P
-import Papa.Base.Implement as P
+import Papa.Base.Export
+import Papa.Base.Implement

--- a/papa-bifunctors-export/src/Papa/Bifunctors/Export.hs
+++ b/papa-bifunctors-export/src/Papa/Bifunctors/Export.hs
@@ -1,18 +1,29 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Bifunctors.Export( 
-  module P
+  Biapplicative(bipure, (<<*>>), (*>>), (<<*)), (<<$>>), (<<**>>), biliftA2, biliftA3,
+  Bifoldable(bifold, bifoldMap), bifoldr, bifoldl, bifoldr', bifoldrM, bifoldl', bifoldlM, bitraverse_, bifor_, bimapM_, biforM_, bimsum, bisequenceA_, bisequence_, biasum, biList, binull, bilength, bielem, bisum, biproduct, biand, bior, biany, biall, binotElem, bifind, -- todo re-implement some of these
+  Biff, Biff(runBiff),
+  Clown, Clown(runClown),
+  Fix, Fix(out),
+  Flip, Flip(runFlip),
+  BifunctorFunctor(bifmap), BifunctorMonad(bireturn, bibind, bijoin), biliftM, BifunctorComonad(biextract, biextend, biduplicate), biliftW,
+  Join(Join, runJoin),
+  Joker(Joker, runJoker),
+  Tannen(Tannen, runTannen),
+  WrappedBifunctor(WrapBifunctor, unwrapBifunctor),
+  Bitraversable(bitraverse), bisequenceA, bisequence, bimapM, bifor, biforM, bimapAccumL, bimapAccumR, bimapDefault, bifoldMapDefault
 ) where
 
-import Data.Biapplicative as P(Biapplicative(bipure, (<<*>>), (*>>), (<<*)), (<<$>>), (<<**>>), biliftA2, biliftA3)
-import Data.Bifoldable as P(Bifoldable(bifold, bifoldMap), bifoldr, bifoldl, bifoldr', bifoldrM, bifoldl', bifoldlM, bitraverse_, bifor_, bimapM_, biforM_, bimsum, bisequenceA_, bisequence_, biasum, biList, binull, bilength, bielem, bisum, biproduct, biand, bior, biany, biall, binotElem, bifind) -- todo re-implement some of these
-import Data.Bifunctor.Biff as P(Biff, Biff(runBiff))
-import Data.Bifunctor.Clown as P(Clown, Clown(runClown))
-import Data.Bifunctor.Fix as P(Fix, Fix(out))
-import Data.Bifunctor.Flip as P(Flip, Flip(runFlip))
-import Data.Bifunctor.Functor as P(BifunctorFunctor(bifmap), BifunctorMonad(bireturn, bibind, bijoin), biliftM, BifunctorComonad(biextract, biextend, biduplicate), biliftW)
-import Data.Bifunctor.Join as P(Join(Join, runJoin))
-import Data.Bifunctor.Joker as P(Joker(Joker, runJoker))
-import Data.Bifunctor.Tannen as P(Tannen(Tannen, runTannen))
-import Data.Bifunctor.Wrapped as P(WrappedBifunctor(WrapBifunctor, unwrapBifunctor))
-import Data.Bitraversable as P(Bitraversable(bitraverse), bisequenceA, bisequence, bimapM, bifor, biforM, bimapAccumL, bimapAccumR, bimapDefault, bifoldMapDefault)
+import Data.Biapplicative (Biapplicative(bipure, (<<*>>), (*>>), (<<*)), (<<$>>), (<<**>>), biliftA2, biliftA3)
+import Data.Bifoldable (Bifoldable(bifold, bifoldMap), bifoldr, bifoldl, bifoldr', bifoldrM, bifoldl', bifoldlM, bitraverse_, bifor_, bimapM_, biforM_, bimsum, bisequenceA_, bisequence_, biasum, biList, binull, bilength, bielem, bisum, biproduct, biand, bior, biany, biall, binotElem, bifind) -- todo re-implement some of these
+import Data.Bifunctor.Biff (Biff, Biff(runBiff))
+import Data.Bifunctor.Clown (Clown, Clown(runClown))
+import Data.Bifunctor.Fix (Fix, Fix(out))
+import Data.Bifunctor.Flip (Flip, Flip(runFlip))
+import Data.Bifunctor.Functor (BifunctorFunctor(bifmap), BifunctorMonad(bireturn, bibind, bijoin), biliftM, BifunctorComonad(biextract, biextend, biduplicate), biliftW)
+import Data.Bifunctor.Join (Join(Join, runJoin))
+import Data.Bifunctor.Joker (Joker(Joker, runJoker))
+import Data.Bifunctor.Tannen (Tannen(Tannen, runTannen))
+import Data.Bifunctor.Wrapped (WrappedBifunctor(WrapBifunctor, unwrapBifunctor))
+import Data.Bitraversable (Bitraversable(bitraverse), bisequenceA, bisequence, bimapM, bifor, biforM, bimapAccumL, bimapAccumR, bimapDefault, bifoldMapDefault)

--- a/papa-bifunctors-implement/src/Papa/Bifunctors/Implement.hs
+++ b/papa-bifunctors-implement/src/Papa/Bifunctors/Implement.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Bifunctors.Implement( 
-  module P
+  module Papa.Bifunctors.Implement.Data.Bifoldable
 ) where
 
-import Papa.Bifunctors.Implement.Data.Bifoldable as P
+import Papa.Bifunctors.Implement.Data.Bifoldable

--- a/papa-bifunctors/src/Papa/Bifunctors.hs
+++ b/papa-bifunctors/src/Papa/Bifunctors.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Bifunctors(
-  module P
+    module Papa.Bifunctors.Export,
+    module Papa.Bifunctors.Implement
 ) where
 
-import Papa.Bifunctors.Export as P
-import Papa.Bifunctors.Implement as P
+import Papa.Bifunctors.Export
+import Papa.Bifunctors.Implement
 

--- a/papa-lens-export/src/Papa/Lens/Export.hs
+++ b/papa-lens-export/src/Papa/Lens/Export.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
-module Papa.Lens.Export( 
+module Papa.Lens.Export(
   module P
 ) where
 

--- a/papa-lens-implement/src/Papa/Lens/Implement.hs
+++ b/papa-lens-implement/src/Papa/Lens/Implement.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Lens.Implement( 
-  module P
+    module Papa.Lens.Implement.Data.Collapse,
+    module Papa.Lens.Implement.Data.List,
+    module Papa.Lens.Implement.Data.Tuple
 ) where
 
-import Papa.Lens.Implement.Data.Collapse as P
-import Papa.Lens.Implement.Data.List as P
-import Papa.Lens.Implement.Data.Tuple as P
+import Papa.Lens.Implement.Data.Collapse
+import Papa.Lens.Implement.Data.List
+import Papa.Lens.Implement.Data.Tuple

--- a/papa-lens/src/Papa/Lens.hs
+++ b/papa-lens/src/Papa/Lens.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Lens(
-  module P
+  module Papa.Lens.Export,
+  module Papa.Lens.Implement
 ) where
 
-import Papa.Lens.Export as P
-import Papa.Lens.Implement as P
+import Papa.Lens.Export
+import Papa.Lens.Implement

--- a/papa-semigroupoids-export/src/Papa/Semigroupoids/Export.hs
+++ b/papa-semigroupoids-export/src/Papa/Semigroupoids/Export.hs
@@ -1,21 +1,35 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Semigroupoids.Export( 
-  module P
+  Bifunctor(bimap, first, second), Biapply((<<.>>), (.>>), (<<.)), (<<$>>), (<<..>>), bilift2, bilift3,
+  Alt((<!>)),
+  Apply((<.>), (.>), (<.)), (<..>), liftF2, liftF3, WrappedApplicative(unwrapApplicative), MaybeApply(runMaybeApply),
+  Bind((>>-), join), (-<<), (-<-), (->-), apDefault, returning,
+  BindTrans(liftB),
+  Extend(duplicated, extended),
+  Plus(zero),
+  Groupoid(inv),
+  Bifoldable1(bifold1, bifoldMap1), bitraverse1_, bifor1_, bisequenceA1_, bifoldMapDefault1,
+  Bitraversable1(bitraverse1, bisequence1), bifoldMap1Default,
+  Foldable1(fold1, foldMap1), intercalate1, intercalateMap1, traverse1_, for1_, sequenceA1_, foldMapDefault1, asum1,
+  Traversable1(traverse1, sequence1), foldMap1Default,
+  Semigroupoid(o), WrappedCategory(unwrapCategory), Semi(getSemi),
+  Ob(semiid),
+  Static(runStatic)
 ) where
 
-import Data.Bifunctor.Apply as P(Bifunctor(bimap, first, second), Biapply((<<.>>), (.>>), (<<.)), (<<$>>), (<<..>>), bilift2, bilift3)
-import Data.Functor.Alt as P(Alt((<!>)))
-import Data.Functor.Apply as P(Apply((<.>), (.>), (<.)), (<..>), liftF2, liftF3, WrappedApplicative(unwrapApplicative), MaybeApply(runMaybeApply))
-import Data.Functor.Bind as P(Bind((>>-), join), (-<<), (-<-), (->-), apDefault, returning)
-import Data.Functor.Bind.Trans as P(BindTrans(liftB))
-import Data.Functor.Extend as P(Extend(duplicated, extended))
-import Data.Functor.Plus as P(Plus(zero))
-import Data.Groupoid as P(Groupoid(inv))
-import Data.Semigroup.Bifoldable as P(Bifoldable1(bifold1, bifoldMap1), bitraverse1_, bifor1_, bisequenceA1_, bifoldMapDefault1)
-import Data.Semigroup.Bitraversable as P(Bitraversable1(bitraverse1, bisequence1), bifoldMap1Default)
-import Data.Semigroup.Foldable as P(Foldable1(fold1, foldMap1), intercalate1, intercalateMap1, traverse1_, for1_, sequenceA1_, foldMapDefault1, asum1)
-import Data.Semigroup.Traversable as P(Traversable1(traverse1, sequence1), foldMap1Default)
-import Data.Semigroupoid as P(Semigroupoid(o), WrappedCategory(unwrapCategory), Semi(getSemi))
-import Data.Semigroupoid.Ob as P(Ob(semiid))
-import Data.Semigroupoid.Static as P(Static(runStatic))
+import Data.Bifunctor.Apply (Bifunctor(bimap, first, second), Biapply((<<.>>), (.>>), (<<.)), (<<$>>), (<<..>>), bilift2, bilift3)
+import Data.Functor.Alt (Alt((<!>)))
+import Data.Functor.Apply (Apply((<.>), (.>), (<.)), (<..>), liftF2, liftF3, WrappedApplicative(unwrapApplicative), MaybeApply(runMaybeApply))
+import Data.Functor.Bind (Bind((>>-), join), (-<<), (-<-), (->-), apDefault, returning)
+import Data.Functor.Bind.Trans (BindTrans(liftB))
+import Data.Functor.Extend (Extend(duplicated, extended))
+import Data.Functor.Plus (Plus(zero))
+import Data.Groupoid (Groupoid(inv))
+import Data.Semigroup.Bifoldable (Bifoldable1(bifold1, bifoldMap1), bitraverse1_, bifor1_, bisequenceA1_, bifoldMapDefault1)
+import Data.Semigroup.Bitraversable (Bitraversable1(bitraverse1, bisequence1), bifoldMap1Default)
+import Data.Semigroup.Foldable (Foldable1(fold1, foldMap1), intercalate1, intercalateMap1, traverse1_, for1_, sequenceA1_, foldMapDefault1, asum1)
+import Data.Semigroup.Traversable (Traversable1(traverse1, sequence1), foldMap1Default)
+import Data.Semigroupoid (Semigroupoid(o), WrappedCategory(unwrapCategory), Semi(getSemi))
+import Data.Semigroupoid.Ob (Ob(semiid))
+import Data.Semigroupoid.Static (Static(runStatic))

--- a/papa-semigroupoids-implement/src/Papa/Semigroupoids/Implement.hs
+++ b/papa-semigroupoids-implement/src/Papa/Semigroupoids/Implement.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Semigroupoids.Implement( 
-  module P
+  module Papa.Semigroupoids.Implement.Data.Functor.Bind,
+  module Papa.Semigroupoids.Implement.Data.Semigroup.Foldable
 ) where
 
-import Papa.Semigroupoids.Implement.Data.Functor.Bind as P
-import Papa.Semigroupoids.Implement.Data.Semigroup.Foldable as P
+import Papa.Semigroupoids.Implement.Data.Functor.Bind
+import Papa.Semigroupoids.Implement.Data.Semigroup.Foldable

--- a/papa-semigroupoids/src/Papa/Semigroupoids.hs
+++ b/papa-semigroupoids/src/Papa/Semigroupoids.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Semigroupoids(
-  module P
+    module Papa.Semigroupoids.Export,
+    module Papa.Semigroupoids.Implement
 ) where
 
-import Papa.Semigroupoids.Export as P
-import Papa.Semigroupoids.Implement as P
+import Papa.Semigroupoids.Export
+import Papa.Semigroupoids.Implement

--- a/papa-x/src/Papa/X.hs
+++ b/papa-x/src/Papa/X.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.X(
-  module P
+  module Papa.X.Export,
+  module Papa.X.Implement
 ) where
 
-import Papa.X.Export as P
-import Papa.X.Implement as P
+import Papa.X.Export
+import Papa.X.Implement

--- a/papa/src/Papa.hs
+++ b/papa/src/Papa.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa(
-  module P
+  module Papa.Base,
+  module Papa.Bifunctors,
+  module Papa.Lens,
+  module Papa.Semigroupoids
 ) where
 
-import Papa.Base as P
-import Papa.Bifunctors as P
-import Papa.Lens as P
-import Papa.Semigroupoids as P
+import Papa.Base
+import Papa.Bifunctors
+import Papa.Lens
+import Papa.Semigroupoids


### PR DESCRIPTION
We're kind of hamstrung by a number of bugs in haddock, a few of
which you can find here: https://github.com/haskell/haddock/issues/584

Everything now has haddocks except for Papa.Lens.Export, which will
need an explicit export list to work.