### PR TITLE
Don't export the String type alias from Data.String

### DIFF
--- a/papa-base-export/src/Papa/Base/Export/Data/String.hs
+++ b/papa-base-export/src/Papa/Base/Export/Data/String.hs
@@ -1,16 +1,16 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 
 module Papa.Base.Export.Data.String(
-    String
-  , lines
+  -- String
+    lines
   , words
   , unlines
   , unwords
 ) where
 
 import Data.String (
-    String
-  , lines
+  -- String
+    lines
   , words
   , unlines
   , unwords


### PR DESCRIPTION
It's not shorter nor more clear than [Char]